### PR TITLE
fix: homepage title, GA4 opt-out, font loading, OG image, Giscus comm…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,16 +23,15 @@ lazy_load                : true
 # theme                    : minimal-mistakes-jekyll
 remote_theme             : "mmistakes/minimal-mistakes"
 comments:
-  provider               : "disqus" # false (default), "disqus", "facebook", "google-plus", custom"
+  provider               : "custom"
   disqus:
-    shortname            : "wwwdigitalbiascom" # https://help.disqus.com/customer/portal/articles/466208-what-s-a-shortname-
+    shortname            : "wwwdigitalbiascom"
   discourse:
-    server               : # https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963 , e.g.: meta.discourse.org
+    server               :
   facebook:
-    # https://developers.facebook.com/docs/plugins/comments
     appid                :
-    num_posts            : # 5 (default)
-    colorscheme          : # "light" (default), "dark"
+    num_posts            :
+    colorscheme          :
 staticman:
   allowedFields          : ['name', 'email', 'url', 'message']
   branch                 : # "master", "gh-pages"
@@ -48,10 +47,19 @@ staticman:
     date:
       type               : "date"
       options:
-        format           : "iso8601" # "iso8601" (default), "timestamp-seconds", "timestamp-milliseconds"
+        format           : "iso8601"
 atom_feed:
-  path                   : # blank (default) uses feed.xml
+  path                   :
 repository               : digitalbias/digitalbias.github.io.
+
+# Giscus comments — https://giscus.app
+# Setup: 1) enable Discussions on this repo  2) install https://github.com/apps/giscus
+#        3) visit giscus.app to retrieve repo_id and category_id
+giscus:
+  repo        : "digitalbias/digitalbias.github.io"
+  repo_id     : ""   # paste from giscus.app
+  category    : "Announcements"
+  category_id : ""   # paste from giscus.app
 
 # SEO Related
 google_site_verification :
@@ -66,7 +74,7 @@ facebook:
   username               :
   app_id                 :
   publisher              :
-og_image                 : # Open Graph/Twitter default site image
+og_image                 : /images/highrise.jpg
 # For specifying social profiles
 # - https://developers.google.com/structured-data/customize/social-profiles
 social:
@@ -75,13 +83,8 @@ social:
   links: # An array of links to social media profiles
 
 # Analytics
-# analytics:
-#   provider               : "google" # false (default), "google", "google-universal", "custom"
-#   google:
-#     tracking_id          : UA-256389-2
-
 analytics:
-  provider               : "google-gtag" # false (default), "google", "google-universal", "custom"
+  provider               : "google-gtag"
   google:
     tracking_id          : G-2HXQH8LP0C
 
@@ -108,7 +111,7 @@ author:
   linkedin         : digitalbias
   pinterest        :
   soundcloud       :
-  stackoverflow    : # "123456/username" (the last part of your profile url, e.g. http://stackoverflow.com/users/123456/username)
+  stackoverflow    :
   steam            :
   tumblr           :
   twitter          : digitalbias
@@ -176,7 +179,7 @@ kramdown:
 # Sass/SCSS
 sass:
   sass_dir: _sass
-  style: compressed # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style
+  style: compressed
 
 
 # Outputting

--- a/_includes/comments-providers/custom.html
+++ b/_includes/comments-providers/custom.html
@@ -1,0 +1,16 @@
+<script src="https://giscus.app/client.js"
+  data-repo="{{ site.giscus.repo }}"
+  data-repo-id="{{ site.giscus.repo_id }}"
+  data-category="{{ site.giscus.category }}"
+  data-category-id="{{ site.giscus.category_id }}"
+  data-mapping="pathname"
+  data-strict="0"
+  data-reactions-enabled="1"
+  data-emit-metadata="0"
+  data-input-position="top"
+  data-theme="preferred_color_scheme"
+  data-lang="en"
+  data-loading="lazy"
+  crossorigin="anonymous"
+  async>
+</script>

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,2 +1,5 @@
 <meta name="theme-color" content="#f8f3e8" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e1a1e" media="(prefers-color-scheme: dark)">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=Manrope:wght@400;500;600;700;800&display=swap">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -4,8 +4,6 @@ search: false
 ---
 @charset "utf-8";
 
-@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=Manrope:wght@400;500;600;700;800&display=swap");
-
 @import "minimal-mistakes/skins/default";
 @import "minimal-mistakes";
 

--- a/assets/js/ga_opt_out.js
+++ b/assets/js/ga_opt_out.js
@@ -1,13 +1,10 @@
-// Set to the same value as the web property used on the site
-var gaProperty = 'UA-256389-2';
-
-// Disable tracking if the opt-out cookie exists.
+// Opt-out of Google Analytics (GA4)
+var gaProperty = 'G-2HXQH8LP0C';
 var disableStr = 'ga-disable-' + gaProperty;
 if (document.cookie.indexOf(disableStr + '=true') > -1) {
   window[disableStr] = true;
 }
 
-// Opt-out function
 function gaOptout() {
   document.cookie = disableStr + '=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';
   window[disableStr] = true;

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ header:
   actions:
     - label: "<i class='fa fa-envelope'></i> Download a sample chapter"
       url: "/mba_notebook/"
-title: The Essential MBA
+title: David C Mitchell
 layout: splash
 excerpt: "Practical writing, business thinking, and long-horizon projects from David Mitchell."
 author_profile: false


### PR DESCRIPTION
…ents

- index.html: title was 'The Essential MBA' which set browser tab / social card title incorrectly; changed to 'David C Mitchell'
- ga_opt_out.js: was targeting retired UA-256389-2; updated to live GA4 property G-2HXQH8LP0C so the opt-out cookie actually works
- main.scss: remove CSS @import for Google Fonts (render-blocking)
- head/custom.html: replace @import with preconnect + <link> so fonts are discovered early and load in parallel with other assets
- _config.yml: set og_image to highrise.jpg, switch comments provider from disqus to custom, add giscus config block (fill in repo_id and category_id from giscus.app after enabling Discussions on this repo)
- comments-providers/custom.html: new Giscus template; theme is set to preferred_color_scheme so it follows OS dark/light automatically